### PR TITLE
Update api Dockerfile for bundler version bug

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN gem install bundler --without test
+RUN gem install bundler -v 2.3.27 --without test
 
 WORKDIR /app
 


### PR DESCRIPTION
RubyGems version 2.7.6.2 has a bug that prevents `required_ruby_version` from working for Bundler. Edited the Docker file to specify the latest bundler version that is supported by 2.7.6.2